### PR TITLE
Add error param to diskspace callback.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,18 +9,22 @@ var smallest;
 
 function checkFnc(dev)
 {
-	return function(total, free, status)
+	return function(error, total, free, status)
 	{
-		var perc = 1.0 - (free / total);
-		if (!smallest || smallest <  perc)
-		{
-			smallest = perc;
-			smallestDev = dev;
-		}
+		if (!error) {
+			var perc = 1.0 - (free / total);
+			if (!smallest || smallest <  perc)
+			{
+				smallest = perc;
+				smallestDev = dev;
+			}
 
-		if (!--c)
-		{
-			console.log('DISKUSE_SUMMARY %d', smallest);
+			if (!--c)
+			{
+				console.log('DISKUSE_SUMMARY %d', smallest);
+			}
+		} else {
+			--c;
 		}
 	}
 }


### PR DESCRIPTION
diskspace 0.1.7 expects an error parameter as the first parameter of the callback (this is different from diskspace 0.1.5, which this plugin had been using previously).

https://github.com/keverw/diskspace.js/commit/d690faad01fdf76f001d85e92fb8a5e67eebaadc